### PR TITLE
Add setuptools version 81 runtime requirement for pkg_resources

### DIFF
--- a/prod_macros.xml
+++ b/prod_macros.xml
@@ -4,6 +4,7 @@
         <requirements>
             <requirement type="package" version="@VERSION@">immuneML</requirement>
             <requirement type="package" version="3.10.*">python</requirement>
+            <requirement type="package" version="81.0.0">setuptools</requirement>
         </requirements>
     </xml>
 </macros>


### PR DESCRIPTION

## Summary

This PR adds an explicit `setuptools` runtime requirement to the Galaxy wrapper macros.

immuneML currently imports `pkg_resources` at runtime. In Galaxy Conda tool environments, `pkg_resources` ismissing when `setuptools >=82.0.0` is selected, because `pkg_resources` was removed from setuptools starting with version `82.0.0`. Therefore, this PR explicitly pins `setuptools` to version `81.0.0`, which is still before the removal.

## Why this is needed

When running immuneML Galaxy tools, the tool environment can fail with:

```text
ModuleNotFoundError: No module named 'pkg_resources'
